### PR TITLE
Set device to get correct meminfo

### DIFF
--- a/cuda-smi.cpp
+++ b/cuda-smi.cpp
@@ -22,8 +22,9 @@ int main() {
     CUDA_CALL(cudaGetDeviceCount, &cudaDeviceCount);
 
     for (int deviceId = 0; deviceId < cudaDeviceCount; ++deviceId) {
+        CUDA_CALL(cudaSetDevice, deviceId);
         CUDA_CALL(cudaGetDeviceProperties, &deviceProp, deviceId);
-        
+
         //std::cout.imbue(std::locale("en_US.utf8"));
         std::cout << "Device " << deviceId;
         std::cout << " [PCIe " << deviceProp.pciDomainID << ":" << deviceProp.pciBusID


### PR DESCRIPTION
**Before**

```
% ./cuda-smi
Device 0 [PCIe 0:193:0.0]: GeForce GTX TITAN X (CC 5.2): 12145 of 12288 MB (i.e. 98.8%) Free
Device 1 [PCIe 0:1:0.0]: GeForce GT 650M (CC 3.0): 12145 of 12288 MB (i.e. 98.8%) Free
```

**After**

```
% ./cuda-smi
Device 0 [PCIe 0:193:0.0]: GeForce GTX TITAN X (CC 5.2): 12145 of 12288 MB (i.e. 98.8%) Free
Device 1 [PCIe 0:1:0.0]: GeForce GT 650M (CC 3.0): 43.344 of 1023.7 MB (i.e. 4.23%) Free
```
