### PR TITLE
add cmake build file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.6)
+
+cmake_policy(SET CMP0048 NEW)
+project(cuda-semi LANGUAGES CXX C)
+
+find_package(CUDA  REQUIRED)
+include_directories("${CUDA_INCLUDE_DIRS}")
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -gencode arch=compute_30,code=sm_30)
+
+file(GLOB SRC_FILES  *.cpp)
+cuda_add_executable(cuda-semi ${SRC_FILES})


### PR DESCRIPTION
CMake does a good job with finding the nvcc compiler on different machines. On Mac OS X is for example nvcc not reachable using the default path variable settings. 